### PR TITLE
feat: Allow closing textinputs with enter and escape keys

### DIFF
--- a/components-sdk/src/CapsuleButton.tsx
+++ b/components-sdk/src/CapsuleButton.tsx
@@ -11,6 +11,7 @@ import SelectIcon from "./icons/Select.svg";
 import {default_settings} from "./Capsule";
 import {useCallback, useEffect, useRef, useState} from "react";
 import {Component} from "./utils/componentTypes";
+import { useStateOpen } from './utils/useStateOpen';
 
 export type capsuleButtonCtx = 'main' | 'container' | 'inline' | 'button-row' | 'frame';
 
@@ -21,23 +22,14 @@ type props = {
 };
 
 export function CapsuleButton({context, callback, className} : props) {
-    const [open, setOpen] = useState(false);
+    const {open, setOpen, ignoreRef} = useStateOpen(false);
     const cls = className ? " " + className : "";
-    const btn = useRef<HTMLDivElement>(null);
     const btn_select = useRef<HTMLDivElement>(null);
-    const documentClick = useCallback((ev: MouseEvent) => {
-        if (btn.current && !btn.current.contains(ev.target as HTMLElement)) setOpen(false);
-    }, [btn.current]);
-
-    useEffect(() => {
-        document.addEventListener('mousedown', documentClick);
-        return () => document.removeEventListener('mousedown', documentClick);
-    }, []);
 
     return (
         <div className={Styles.large_button + cls} onClick={(ev) => {
             setOpen(!(btn_select.current && btn_select.current.contains(ev.target as HTMLElement)));
-        }} ref={btn}>
+        }} ref={ignoreRef}>
             <img  className={Styles.large_button_icon} src={Icons} alt=""/>
             {context === "main" && "Add component"}
             {context === "inline" && "Add inline component"}

--- a/components-sdk/src/components/Button.module.css
+++ b/components-sdk/src/components/Button.module.css
@@ -55,3 +55,17 @@
     text-overflow: ellipsis;
   }
 }
+
+.menu_label {
+  position: relative;
+  padding-right: 7px;
+  img {
+    width: 25px;
+    height: 25px;
+    padding: 7px;
+    cursor: pointer;
+    position: absolute;
+    top:0;
+    right: 0;
+  }
+}

--- a/components-sdk/src/components/Button.tsx
+++ b/components-sdk/src/components/Button.tsx
@@ -218,6 +218,11 @@ export function MenuLabel({state, stateKey, stateManager, setOpen, nullable = fa
         className={Styles.input}
         placeholder="abcdefg"
         onChange={(ev) => stateManager.setKey({key: stateKey, value: nullable ? (ev.target.value || null) : ev.target.value})}
+        onKeyUp={(ev) => {
+            if (ev.key == "Enter" || ev.key == "Escape"){
+                setOpen(0);
+            }
+        }}
         onBlur={() => setOpen(0)}
     />
 }

--- a/components-sdk/src/components/Container.tsx
+++ b/components-sdk/src/components/Container.tsx
@@ -6,26 +6,15 @@ import CapsuleStyles from "../Capsule.module.css";
 import ColorActiveIcon from "../icons/ColorActive.svg";
 import SpoilerActiveIcon from "../icons/SpoilerActive.svg";
 import {ChromePicker} from "react-color";
-import {useCallback, useEffect, useRef, useState} from "react";
 import {ComponentsProps} from "../Capsule";
 import {ContainerComponent} from "../utils/componentTypes";
+import { useStateOpen } from '../utils/useStateOpen';
 
 
 export function Container({state, stateKey, stateManager, passProps} : ComponentsProps & {state: ContainerComponent}) {
     const hasColor = state.accent_color !== null;
     const colorHex = "#" + Number(state.accent_color || 0).toString(16).padStart(6, '0');
-
-    const picker = useRef<HTMLDivElement>(null);
-    const [pickerOpen, setPickerOpen] = useState(false);
-    const documentClick = useCallback((ev: MouseEvent) => {
-        if (picker.current) setPickerOpen(picker.current.contains(ev.target as HTMLElement));
-    }, [picker.current]);
-
-    useEffect(() => {
-        document.addEventListener('mousedown', documentClick);
-        return () => document.removeEventListener('mousedown', documentClick);
-    }, []);
-
+    const {open: pickerOpen, setOpen: setPickerOpen, ignoreRef: picker} = useStateOpen(false);
 
     return <div className={Styles.embed + ' ' + (state.spoiler ? Styles.spoiler : "")}>
         {hasColor && <div className={Styles.bar} style={{backgroundColor: colorHex}} />}
@@ -40,8 +29,8 @@ export function Container({state, stateKey, stateManager, passProps} : Component
             // buttonClassName={CapsuleStyles.inline}
             passProps={passProps}
         />
-        <div className={CapsuleStyles.large_button + " " + CapsuleStyles.small} ref={picker}>
-            { pickerOpen && <div className={CapsuleStyles.large_button_ctx}>
+        <div className={CapsuleStyles.large_button + " " + CapsuleStyles.small} onClick={() => setPickerOpen(true)}>
+            { pickerOpen && <div className={CapsuleStyles.large_button_ctx} ref={picker}>
                 <ChromePicker
                     color={colorHex}
                     onChange={(ev: any) => {

--- a/components-sdk/src/components/StringSelect.tsx
+++ b/components-sdk/src/components/StringSelect.tsx
@@ -9,6 +9,7 @@ import {StringSelectComponent, StringSelectComponentOption} from "../utils/compo
 import {stateKeyType} from "../polyfills/StateManager";
 import Slider from "rc-slider";
 import TrashIcon from "../icons/Trash.svg";
+import { useStateOpen } from '../utils/useStateOpen';
 
 export function StringSelect({state, stateKey, stateManager, passProps} : ComponentsProps & {state: StringSelectComponent}) {
     useEffect(() => {
@@ -58,23 +59,13 @@ function GlobalSettings({state, stateKey, stateManager} : {
     stateKey: ComponentsProps['stateKey'],
     stateManager: ComponentsProps['stateManager'],
 }) {
-    const [open, setOpen] = useState(0);
-    const btn = useRef<HTMLDivElement>(null);
+    const {open, setOpen, ignoreRef, closeLockRef} = useStateOpen(0);
     const btn_select = useRef<HTMLDivElement>(null);
-
-    const documentClick = useCallback((ev: MouseEvent) => {
-        if (btn.current && !btn.current.contains(ev.target as HTMLElement)) setOpen(0);
-    }, [btn.current]);
-
-    useEffect(() => {
-        document.addEventListener('mousedown', documentClick);
-        return () => document.removeEventListener('mousedown', documentClick);
-    }, []);
 
     return <div className={Styles.select_option + ' ' + Styles.select_default + (open ? " " + Styles.open :  "")} onClick={(ev) => {
         if (btn_select.current && btn_select.current.contains(ev.target as HTMLElement)) return;
         setOpen(1)
-    }} ref={btn}>
+    }} ref={ignoreRef}>
         <div className={Styles.icon}><img src={EditIcon} alt="(Edit)"/></div>
         <div className={Styles.with_badge}>
             <div className={Styles.text}>{state.placeholder || "Global settings"}</div>
@@ -82,7 +73,7 @@ function GlobalSettings({state, stateKey, stateManager} : {
         </div>
         { !!open && <div className={CapsuleStyles.large_button_ctx+ ' ' + CapsuleStyles.noright} ref={btn_select}>
             {open === 1 && <GlobalSettingsFirst state={state} stateKey={stateKey} stateManager={stateManager} setOpen={setOpen}/>}
-            {open === 2 && <MenuLabel state={state.placeholder || ""} stateKey={[...stateKey, 'placeholder']} stateManager={stateManager} setOpen={setOpen}/>}
+            {open === 2 && <MenuLabel closeLockRef={closeLockRef} state={state.placeholder || ""} stateKey={[...stateKey, 'placeholder']} stateManager={stateManager} setOpen={setOpen}/>}
             {open === 3 && <MenuRange min={1} max={state.options.length} state={state.min_values} stateKey={[...stateKey, 'min_values']} stateManager={stateManager}/>}
             {open === 4 && <MenuRange min={1} max={state.options.length} state={state.max_values} stateKey={[...stateKey, 'max_values']} stateManager={stateManager}/>}
         </div>}
@@ -161,25 +152,15 @@ function StringSelectOption({state, stateKey, stateManager, passProps} : {
     stateManager: ComponentsProps['stateManager'],
     passProps: ComponentsProps['passProps']
 }) {
-    const [open, setOpen] = useState(0);
-    const btn = useRef<HTMLDivElement>(null);
+    const {open, setOpen, ignoreRef, closeLockRef} = useStateOpen(0);
     const btn_select = useRef<HTMLDivElement>(null);
-    const documentClick = useCallback((ev: MouseEvent) => {
-        if (btn.current && !btn.current.contains(ev.target as HTMLElement)) setOpen(0);
-    }, [btn.current]);
-
     const Comp = passProps.EmojiShow;
-
-    useEffect(() => {
-        document.addEventListener('mousedown', documentClick);
-        return () => document.removeEventListener('mousedown', documentClick);
-    }, []);
 
     return (
         <div className={Styles.select_option + (open ? " " + Styles.open : "") + (state.default ? " " + Styles.blue : "") + (state.disabled ? " " + Styles.disabled : "")} onClick={(ev) => {
             if (btn_select.current && btn_select.current.contains(ev.target as HTMLElement)) return;
             setOpen(1)
-        }} ref={btn}>
+        }} ref={useRef}>
             {state.emoji !== null && <div className={CapsuleStyles.emoji}>
                 <Comp passProps={passProps} emoji={state.emoji} />
             </div>}
@@ -189,8 +170,8 @@ function StringSelectOption({state, stateKey, stateManager, passProps} : {
             { !!open && <div className={CapsuleStyles.large_button_ctx+ ' ' + CapsuleStyles.noright} ref={btn_select}>
                 {open === 1 && <MenuFirst state={state} stateKey={stateKey} stateManager={stateManager} setOpen={setOpen}/>}
                 {open === 2 && <MenuEmoji stateKey={[...stateKey, 'emoji']} stateManager={stateManager} passProps={passProps}/>}
-                {open === 3 && <MenuLabel state={state.label} stateKey={[...stateKey, 'label']} stateManager={stateManager} setOpen={setOpen}/>}
-                {open === 4 && <MenuLabel state={state.description || ""} nullable={true} stateKey={[...stateKey, "description"]} stateManager={stateManager} setOpen={setOpen}/>}
+                {open === 3 && <MenuLabel closeLockRef={closeLockRef} state={state.label} stateKey={[...stateKey, 'label']} stateManager={stateManager} setOpen={setOpen}/>}
+                {open === 4 && <MenuLabel closeLockRef={closeLockRef} state={state.description || ""} nullable={true} stateKey={[...stateKey, "description"]} stateManager={stateManager} setOpen={setOpen}/>}
             </div>}
         </div>
     )

--- a/components-sdk/src/components/Thumbnail.tsx
+++ b/components-sdk/src/components/Thumbnail.tsx
@@ -14,11 +14,11 @@ import {stateKeyType} from "../polyfills/StateManager";
 import {useFileUpload} from "../utils/useFileUpload";
 import SpoilerActiveIcon from "../icons/SpoilerActive.svg";
 import SpoilerIcon from "../icons/Spoiler.svg";
+import { useStateOpen } from '../utils/useStateOpen';
 
 
 export function Thumbnail({state, stateKey, stateManager, passProps, removeKeyParent = undefined, className=undefined} : Omit<ComponentsProps, 'state'> & {state: MediaGalleryItem | ThumbnailComponent, className?: string}) {
-    const [open, setOpen] = useState(0);
-    const btn = useRef<HTMLDivElement>(null);
+    const {open, setOpen, ignoreRef, closeLockRef} = useStateOpen(0);
     const btn_select = useRef<HTMLDivElement>(null);
 
     const {src, setSrc, openFileSelector} = useFileUpload(
@@ -27,26 +27,16 @@ export function Thumbnail({state, stateKey, stateManager, passProps, removeKeyPa
         passProps?.getFile, passProps?.setFile, stateManager
     );
 
-    const documentClick = useCallback((ev: MouseEvent) => {
-        if (btn.current && !btn.current.contains(ev.target as HTMLElement)) setOpen(0);
-    }, [btn.current]);
-
-    useEffect(() => {
-        document.addEventListener('mousedown', documentClick);
-        return () => document.removeEventListener('mousedown', documentClick);
-    }, []);
-
-
     return <div className={(className || Styles.thumbnail) + ' ' + (state.spoiler ? Styles.spoiler : '')}
     onClick={(ev) => {
         if (btn_select.current && btn_select.current.contains(ev.target as HTMLElement)) return;
         setOpen(1)
-    }} ref={btn}>
+    }} ref={ignoreRef}>
         <img src={src || ThumbnailIcon} alt=""/>
         {!!open && <div className={CapsuleStyles.large_button_ctx + ' ' + CapsuleStyles.noright} ref={btn_select}>
             {open === 1 && <MenuFirst state={state} stateKey={stateKey} stateManager={stateManager} setOpen={setOpen} removeKeyParent={removeKeyParent} openFileSelector={openFileSelector}/>}
-            {open === 2 && <MenuLabel state={state.media.url} stateKey={[...stateKey, "media", "url"]} stateManager={stateManager} setOpen={setOpen}/>}
-            {open === 3 && <MenuLabel state={state.description || ""} stateKey={[...stateKey, "description"]} stateManager={stateManager} nullable={true} setOpen={setOpen}/>}
+            {open === 2 && <MenuLabel closeLockRef={closeLockRef} state={state.media.url} stateKey={[...stateKey, "media", "url"]} stateManager={stateManager} setOpen={setOpen}/>}
+            {open === 3 && <MenuLabel closeLockRef={closeLockRef} state={state.description || ""} stateKey={[...stateKey, "description"]} stateManager={stateManager} nullable={true} setOpen={setOpen}/>}
         </div>}
 
     </div>

--- a/components-sdk/src/utils/useStateOpen.ts
+++ b/components-sdk/src/utils/useStateOpen.ts
@@ -1,0 +1,35 @@
+import { Dispatch, MutableRefObject, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+
+export function useStateOpen<T>(defaultValue: T): {
+    open: T
+    setOpen: Dispatch<SetStateAction<T>>,
+    ignoreRef: MutableRefObject<HTMLDivElement | null>,
+    closeLockRef: MutableRefObject<any>
+} {
+    const [open, setOpen] = useState(defaultValue);
+    const ignoreRef = useRef<HTMLDivElement>(null);
+    const closeLockRef = useRef<HTMLDivElement>(null);
+
+    const documentClick = useCallback((ev: MouseEvent) => {
+        if (ignoreRef.current && ignoreRef.current.contains(ev.target as HTMLElement)) return;
+        if (closeLockRef.current) return; // if there is any input you cannot close manually
+        setOpen(defaultValue);
+    }, [ignoreRef.current]);
+
+    const documentKeyDown = useCallback((ev: KeyboardEvent) => {
+        if (ev.key == "Enter" || ev.key == "Escape") {
+            setOpen(defaultValue);
+        }
+    }, [])
+
+    useEffect(() => {
+        document.addEventListener('mousedown', documentClick);
+        document.addEventListener('keydown', documentKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', documentClick);
+            document.removeEventListener('keydown', documentKeyDown);
+        }
+    }, []);
+
+    return { open, setOpen, ignoreRef, closeLockRef }
+}


### PR DESCRIPTION
It was quite annoying to have to change focus to close them, this should make it way nicer.

I am also considering whether it would be a good idea to remove the `onBlur`, as it makes copying text quite annoying, as the field closes