### PR TITLE
chore: remove unnecessary jsxinject config

### DIFF
--- a/components-sdk/vite.config.ts
+++ b/components-sdk/vite.config.ts
@@ -15,9 +15,6 @@ export default defineConfig({
             insertTypesEntry: true,
         })
     ],
-    esbuild: {
-        jsxInject: `import React from 'react'`
-    },
     build: {
         sourcemap: true,
         lib: {

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -12,9 +12,6 @@ export default defineConfig(({command, mode}) => ({
         compileDebug: mode === 'development'
     })],
 
-    esbuild: {
-        jsxInject: `import React from 'react'`
-    },
     resolve: (command === 'serve' && mode === 'development') ? {
         // Make library auto-reload only on yarn dev
         alias: [


### PR DESCRIPTION
Silences warning that shows when you run `yarn dev`:

> [@vitejs/plugin-react] This plugin imports React for you automatically, so you can stop using `esbuild.jsxInject` for that purpose.
