### PR TITLE
enhance: Remove url encoding to shorten the url

### DIFF
--- a/website/src/useHashRouter.ts
+++ b/website/src/useHashRouter.ts
@@ -4,9 +4,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { webhookImplementation } from './webhook.impl';
 
 function asciiJSONStringify(obj: any): string {
-	return JSON.stringify(obj).replace(/[\u00FF-\uFFFF]/g, function(chr) {
-		return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).slice(-4)
-	})
+    return JSON.stringify(obj).replace(/[\u00FF-\uFFFF]/g, function(chr) {
+        return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).slice(-4)
+    })
 }
 
 export function useHashRouter() {
@@ -38,7 +38,7 @@ export function useHashRouter() {
 
             let value;
             try {
-				value = JSON.parse(decodeURIComponent(atob(newHash)));
+                value = JSON.parse(decodeURIComponent(atob(newHash)));
             } catch (e) {
                 value = [];
             }

--- a/website/src/useHashRouter.ts
+++ b/website/src/useHashRouter.ts
@@ -3,6 +3,12 @@ import { actions, RootState } from './state';
 import { useDispatch, useSelector } from 'react-redux';
 import { webhookImplementation } from './webhook.impl';
 
+function asciiJSONStringify(obj: any): string {
+	return JSON.stringify(obj).replace(/[\u00FF-\uFFFF]/g, function(chr) {
+		return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).slice(-4)
+	})
+}
+
 export function useHashRouter() {
     const dispatch = useDispatch();
     const currentHash = useRef<string | null>(null);
@@ -16,7 +22,7 @@ export function useHashRouter() {
         }
 
         const getData = setTimeout(() => {
-            const value = btoa(JSON.stringify(state));
+            const value = btoa(asciiJSONStringify(state));
             currentHash.current = value;  // infinite loop resolver
             document.location.hash = value;
         }, 600)

--- a/website/src/useHashRouter.ts
+++ b/website/src/useHashRouter.ts
@@ -16,7 +16,7 @@ export function useHashRouter() {
         }
 
         const getData = setTimeout(() => {
-            const value = btoa(encodeURIComponent(JSON.stringify(state)));
+            const value = btoa(JSON.stringify(state));
             currentHash.current = value;  // infinite loop resolver
             document.location.hash = value;
         }, 600)
@@ -32,7 +32,7 @@ export function useHashRouter() {
 
             let value;
             try {
-                value = JSON.parse(decodeURIComponent(atob(newHash)));
+                value = JSON.parse(atob(newHash));
             } catch (e) {
                 value = [];
             }

--- a/website/src/useHashRouter.ts
+++ b/website/src/useHashRouter.ts
@@ -38,7 +38,7 @@ export function useHashRouter() {
 
             let value;
             try {
-                value = JSON.parse(atob(newHash));
+				value = JSON.parse(decodeURIComponent(atob(newHash)));
             } catch (e) {
                 value = [];
             }


### PR DESCRIPTION
since base64 is alrady in use so nothing needs to be url-escaped
also i'd like to apologise if that's not the right procedure to do pull requests here or if this is required for something somewhere, it bugged me that it was encoded twice so i decided to make a pr

(for empty page, `[]`)
before: `https://discord.builders/#JTVCJTVE`
after: `http://localhost:3000/#W10=`