### PR TITLE
Fix container deletion when removing last component

### DIFF
--- a/components-sdk/src/components/Container.tsx
+++ b/components-sdk/src/components/Container.tsx
@@ -43,7 +43,6 @@ export function Container({
                 stateKey={stateKeyComponents}
                 stateManager={stateManager}
                 showSectionButton={true}
-                removeKeyParent={stateKey}
                 buttonContext={'container'}
                 droppableId={DroppableID.CONTAINER}
                 // buttonClassName={CapsuleStyles.inline}


### PR DESCRIPTION
## Bug
Removing all components inside a container deletes the container itself.

## Expected behavior
The container should remain empty instead of being deleted.

## Fix
Prevent the container from being removed when its last component is deleted.

## Steps to reproduce
1. Create a container
2. Add components
3. Remove all components
4. Container disappears